### PR TITLE
enumerate arbre def

### DIFF
--- a/cm/3.tex
+++ b/cm/3.tex
@@ -27,14 +27,14 @@
 
 \begin{mytheo} [Caractérisations des arbres]
   Soit $G$ un graphe à $n$ sommets et $m$ arêtes. Alors les conditions suivantes sont équivalentes :
-  \begin{itemize}
+  \begin{enumerate}
     \item $G$ est connexe et sans cycle;
     \item $G$ est sans cycle et $m = n − 1$;
     \item $G$ est connexe et $m = n − 1$;
     \item $G$ est connexe et supprimer une arête quelconque déconnecte $G$;
     \item $G$ est sans cycle et ajouter une arête quelconque crée un et un seul cycle;
     \item Deux noeuds de $G$ sont toujours reliés par un seul chemin.
-  \end{itemize}
+  \end{enumerate}
   La dernière condition implique que G est sans boucle (pour deux noeuds identiques).
   \begin{proof}
   Nous allons démontrer que chaque condition implique la suivante et qu'elles sont ainsi toutes équivalentes.


### PR DESCRIPTION
rend plus clair les demo qui suivent en numérotant les enoncées plutot qu'en mettant simplement un point devant.
