### PR TITLE
pentagone = peterson

### DIFF
--- a/ape/8.tex
+++ b/ape/8.tex
@@ -38,7 +38,7 @@
     \item Vrai car $\mathcal{X} \leq$ degré max $+ 1 = 4$. 
     \item  Pas toujours. Le graphe $K_5$ en nécessite $5$ par exemple.
     \item Vrai puisqu'on aura déjà besoin de $5$ pour colorier $K_n$.
-    \item Faux. Prenons par exemple un pentagone. Son nombre chromatique est égal à $3$ sans pour qu'il ne contienne de triangle. En fait, dès qu'on aura un cycle de longueur impaire, on va avoir $n \geq 3 $ sans pour autant que le graphe ne contienne $K_n$.
+    \item Faux. Prenons par exemple le graphe de Péterson. Son nombre chromatique est égal à $3$ sans pour qu'il ne contienne de triangle. En fait, dès qu'on aura un cycle de longueur impaire, on va avoir $n \geq 3 $ sans pour autant que le graphe ne contienne $K_n$.
   \end{enumerate}
 \end{solution}
 


### PR DESCRIPTION
c'est moins ambigu d'utiliser peterson car un pentagone a part qu'il a 5 noeuds, je sais pas ou sont ses aretes
