### PR TITLE
include

### DIFF
--- a/ape/LINMA1691-exercices.tex
+++ b/ape/LINMA1691-exercices.tex
@@ -69,25 +69,15 @@ ou par mail.}
 \pagenumbering{arabic}% Arabic page numbers (and reset to 1)
 \tableofcontents
 
-\newpage
-\input{1.tex}
-\newpage
-\input{2.tex}
-\newpage
-\input{3.tex}
-\newpage
-\input{4.tex}
-\newpage
-\input{5.tex}
-\newpage
-\input{6.tex}
-\newpage
-\input{7.tex}
-\newpage
-\input{8.tex}
-\newpage
-\input{9.tex}
-\newpage
-\input{10.tex}
+\include{1}
+\include{2}
+\include{3}
+\include{4}
+\include{5}
+\include{6}
+\include{7}
+\include{8}
+\include{9}
+\include{10}
 
 \end{document}


### PR DESCRIPTION
comme ca on a direct le clearpage en plus, ca permet d'utiliser la commande \includeonly{filename1,filename2,...} si on ne veux que un exo
